### PR TITLE
Cached errors

### DIFF
--- a/src/actions/createAction.js
+++ b/src/actions/createAction.js
@@ -37,7 +37,7 @@ export function createAction (key, asyncAction, customErrorMessage) {
 
       // toggle to report all ui errors to sentry
       if (config.logUiErrors) {
-        console.log(`key: ${key}, action: ${asyncAction} errorObject: ${JSON.stringify(error)}`);
+        console.log(`key: ${key}\naction: ${asyncAction}\nerrorObject: ${JSON.stringify(error)}`);
         errorService.log(error);
       }
 

--- a/src/actions/createAction.js
+++ b/src/actions/createAction.js
@@ -37,7 +37,7 @@ export function createAction (key, asyncAction, customErrorMessage) {
 
       // toggle to report all ui errors to sentry
       if (config.logUiErrors) {
-        console.log(`key: ${key}\naction: ${asyncAction}\nerrorObject: ${JSON.stringify(error)}`);
+        console.log(`key: ${key}, action: ${asyncAction}, errorObject: ${JSON.stringify(error)}`);
         errorService.log(error);
       }
 

--- a/src/components/walletpicker/WalletPicker.js
+++ b/src/components/walletpicker/WalletPicker.js
@@ -155,7 +155,7 @@ function WalletPicker ({ onEnable }) {
           <img src={logo} alt='logo' />
           <div className={styles.menu}>
             <a
-              href='https://docs.omg.network/quick-start-webwallet'
+              href='https://docs.omg.network/wallet/quick-start-webwallet'
               target='_blank'
               rel='noopener noreferrer'
             >

--- a/src/services/__tests__/errorService.test.js
+++ b/src/services/__tests__/errorService.test.js
@@ -27,13 +27,13 @@ describe('sanitizeError', () => {
     jest.clearAllMocks();
   });
 
-  it('should return metamask unsign error', async () => {
+  it('should not return metamask unsign error', async () => {
     const error = {
       code: 4001,
       message: 'MetaMask Tx Signature: User denied transaction signature'
     };
     const res = await errorService.sanitizeError(error);
-    expect(res).toBe(error.message);
+    expect(res).toBe(null);
   });
 
   it('should ignore metamask -32000 header not found error', async () => {

--- a/src/services/errorService.js
+++ b/src/services/errorService.js
@@ -59,8 +59,8 @@ class ErrorService {
   async sanitizeError (error) {
     // user sign rejection from metamask
     if (
-      error.message.toLowerCase().includes('user denied') ||
-      error.message.toLowerCase().includes('user rejected')
+      error.message && error.message.toLowerCase().includes('user denied') ||
+      error.message && error.message.toLowerCase().includes('user rejected')
     ) {
       return null;
     }

--- a/src/services/errorService.js
+++ b/src/services/errorService.js
@@ -59,8 +59,8 @@ class ErrorService {
   async sanitizeError (error) {
     // user sign rejection from metamask
     if (
-      error.message && error.message.toLowerCase().includes('user denied') ||
-      error.message && error.message.toLowerCase().includes('user rejected')
+      (error.message && error.message.toLowerCase().includes('user denied')) ||
+      (error.message && error.message.toLowerCase().includes('user rejected'))
     ) {
       return null;
     }

--- a/src/services/errorService.js
+++ b/src/services/errorService.js
@@ -24,10 +24,17 @@ if (config.sentry) {
   Sentry.init({ dsn: config.sentry });
 }
 
+const errorCache = [];
+
 class ErrorService {
   log (error) {
     console.warn(error.message);
     if (config.sentry) {
+      if (errorCache.includes(error.message)) {
+        // if message already seen in this session, ignore it
+        return;
+      }
+      errorCache.push(error.message);
       Sentry.captureException(error);
     }
   }
@@ -76,7 +83,6 @@ class ErrorService {
     // default to original error message
     return error.message || 'Something went wrong';
   }
-
 }
 
 const errorService = new ErrorService();

--- a/src/services/errorService.js
+++ b/src/services/errorService.js
@@ -24,11 +24,28 @@ if (config.sentry) {
   Sentry.init({ dsn: config.sentry });
 }
 
+// skip error logging
+const noLogErrors = [
+  'user denied',
+  'user rejected',
+  'server is not ready to handle the request',
+  'insufficient funds',
+  'network error',
+  'transaction has been reverted'
+];
+
+// used to prevent error spam from a single session
 const errorCache = [];
 
 class ErrorService {
   log (error) {
-    console.warn(error.message);
+    // skip logging if in defined list
+    for (const i of noLogErrors) {
+      if (error.message.toLowerCase().includes(i)) {
+        return;
+      }
+    }
+
     if (config.sentry) {
       if (errorCache.includes(error.message)) {
         // if message already seen in this session, ignore it
@@ -41,8 +58,11 @@ class ErrorService {
 
   async sanitizeError (error) {
     // user sign rejection from metamask
-    if (error.code === 4001) {
-      return error.message;
+    if (
+      error.message.toLowerCase().includes('user denied') ||
+      error.message.toLowerCase().includes('user rejected')
+    ) {
+      return null;
     }
 
     // ignore metamask rpc header not found errors


### PR DESCRIPTION
- certain obvious error messages are not sent to sentry
- errors that are bound for sentry are cached so a single user session doesn't report it multiple times (this can cause a lot of spam due to the polling nature of the app)
- fixed about link

https://github.com/omgnetwork/web-wallet/issues/94
https://github.com/omgnetwork/web-wallet/issues/92