### PR TITLE
fix Metamask EOL of Web3.js injection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1349,7 +1349,12 @@
         "@ethersproject/bytes": "^5.0.9",
         "@ethersproject/logger": "^5.0.8",
         "@ethersproject/properties": "^5.0.7",
-        "elliptic": "6.5.3"
+        "elliptic": "^6.5.3"
+      },
+      "dependencies": {
+        "elliptic": {
+          "version": "^6.5.3"
+        }
       }
     },
     "@ethersproject/strings": {
@@ -1912,7 +1917,7 @@
             "@types/bn.js": "^4.11.3",
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
+            "elliptic": "^6.5.3",
             "ethereum-cryptography": "^0.1.3",
             "ethjs-util": "0.1.6",
             "rlp": "^2.2.3"
@@ -1922,6 +1927,9 @@
               "version": "4.11.9",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
               "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+            },
+            "elliptic": {
+              "version": "^6.5.3"
             }
           }
         }
@@ -1996,7 +2004,7 @@
             "@types/bn.js": "^4.11.3",
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
+            "elliptic": "^6.5.3",
             "ethereum-cryptography": "^0.1.3",
             "ethjs-util": "0.1.6",
             "rlp": "^2.2.3"
@@ -2006,6 +2014,9 @@
               "version": "4.11.9",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
               "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+            },
+            "elliptic": {
+              "version": "^6.5.3"
             }
           }
         }
@@ -4291,25 +4302,7 @@
       },
       "dependencies": {
         "elliptic": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-          "requires": {
-            "bn.js": "^4.4.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0",
-            "minimalistic-crypto-utils": "^1.0.0"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.11.9",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
-              "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
-            }
-          }
+          "version": "^6.5.3"
         }
       }
     },
@@ -5227,18 +5220,7 @@
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
         },
         "elliptic": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-          "requires": {
-            "bn.js": "^4.4.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0",
-            "minimalistic-crypto-utils": "^1.0.0"
-          }
+          "version": "^6.5.3"
         }
       }
     },
@@ -6159,24 +6141,13 @@
             "bn.js": "^4.11.8",
             "create-hash": "^1.2.0",
             "drbg.js": "^1.0.1",
-            "elliptic": "^6.5.2",
+            "elliptic": "^6.5.3",
             "nan": "^2.14.0",
             "safe-buffer": "^5.1.2"
           },
           "dependencies": {
             "elliptic": {
-              "version": "6.5.3",
-              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-              "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-              "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
-              }
+              "version": "^6.5.3"
             }
           }
         }
@@ -6193,9 +6164,6 @@
       "integrity": "sha512-NB3DzrTzJFhWkUp+nl2KtUtoFzrfGXTir2S+BU4tXGyXH9vlluPuFpE3pTKeH7+PY460tHLjKzh6K2+TWwW+Ww=="
     },
     "elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "requires": {
         "bn.js": "^4.4.0",
         "brorand": "^1.0.1",
@@ -6211,7 +6179,8 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
         }
-      }
+      },
+      "version": "^6.5.3"
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -7039,25 +7008,14 @@
                 "@types/bn.js": "^4.11.3",
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
+                "elliptic": "^6.5.3",
                 "ethereum-cryptography": "^0.1.3",
                 "ethjs-util": "0.1.6",
                 "rlp": "^2.2.3"
               },
               "dependencies": {
                 "elliptic": {
-                  "version": "6.5.3",
-                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-                  "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-                  "requires": {
-                    "bn.js": "^4.4.0",
-                    "brorand": "^1.0.1",
-                    "hash.js": "^1.0.0",
-                    "hmac-drbg": "^1.0.0",
-                    "inherits": "^2.0.1",
-                    "minimalistic-assert": "^1.0.0",
-                    "minimalistic-crypto-utils": "^1.0.0"
-                  }
+                  "version": "^6.5.3"
                 }
               }
             }
@@ -7070,7 +7028,7 @@
           "requires": {
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
+            "elliptic": "^6.5.3",
             "ethereum-cryptography": "^0.1.3",
             "ethjs-util": "^0.1.3",
             "rlp": "^2.0.0",
@@ -7078,18 +7036,7 @@
           },
           "dependencies": {
             "elliptic": {
-              "version": "6.5.3",
-              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-              "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-              "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
-              }
+              "version": "^6.5.3"
             }
           }
         },
@@ -7177,25 +7124,14 @@
                 "@types/bn.js": "^4.11.3",
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
+                "elliptic": "^6.5.3",
                 "ethereum-cryptography": "^0.1.3",
                 "ethjs-util": "0.1.6",
                 "rlp": "^2.2.3"
               },
               "dependencies": {
                 "elliptic": {
-                  "version": "6.5.3",
-                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-                  "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-                  "requires": {
-                    "bn.js": "^4.4.0",
-                    "brorand": "^1.0.1",
-                    "hash.js": "^1.0.0",
-                    "hmac-drbg": "^1.0.0",
-                    "inherits": "^2.0.1",
-                    "minimalistic-assert": "^1.0.0",
-                    "minimalistic-crypto-utils": "^1.0.0"
-                  }
+                  "version": "^6.5.3"
                 }
               }
             }
@@ -7208,7 +7144,7 @@
           "requires": {
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
+            "elliptic": "^6.5.3",
             "ethereum-cryptography": "^0.1.3",
             "ethjs-util": "^0.1.3",
             "rlp": "^2.0.0",
@@ -7216,18 +7152,7 @@
           },
           "dependencies": {
             "elliptic": {
-              "version": "6.5.3",
-              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-              "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-              "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
-              }
+              "version": "^6.5.3"
             }
           }
         }
@@ -7239,7 +7164,7 @@
       "integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
       "requires": {
         "bn.js": "^4.11.6",
-        "elliptic": "^6.4.0",
+        "elliptic": "^6.5.3",
         "xhr-request-promise": "^0.1.2"
       },
       "dependencies": {
@@ -7249,18 +7174,7 @@
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
         },
         "elliptic": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-          "requires": {
-            "bn.js": "^4.4.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0",
-            "minimalistic-crypto-utils": "^1.0.0"
-          }
+          "version": "^6.5.3"
         }
       }
     },
@@ -7287,7 +7201,7 @@
       "integrity": "sha512-KpXbCKmmBUNUTGh9MRKmNkIPietfhzBqqYqysDavLseIiMUGl95k6UcPEkALAZlj41e9E6yioYXc1PC333RKqw==",
       "requires": {
         "buffer": "^5.2.1",
-        "elliptic": "^6.4.0",
+        "elliptic": "^6.5.3",
         "ethereumjs-abi": "0.6.5",
         "ethereumjs-util": "^5.1.1",
         "tweetnacl": "^1.0.0",
@@ -7300,18 +7214,7 @@
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
         },
         "elliptic": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-          "requires": {
-            "bn.js": "^4.4.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0",
-            "minimalistic-crypto-utils": "^1.0.0"
-          }
+          "version": "^6.5.3"
         },
         "ethereumjs-abi": {
           "version": "0.6.5",
@@ -7329,24 +7232,13 @@
               "requires": {
                 "bn.js": "^4.8.0",
                 "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
+                "elliptic": "^6.5.3",
                 "ethereum-cryptography": "^0.1.3",
                 "rlp": "^2.0.0"
               },
               "dependencies": {
                 "elliptic": {
-                  "version": "6.5.3",
-                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-                  "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-                  "requires": {
-                    "bn.js": "^4.4.0",
-                    "brorand": "^1.0.1",
-                    "hash.js": "^1.0.0",
-                    "hmac-drbg": "^1.0.0",
-                    "inherits": "^2.0.1",
-                    "minimalistic-assert": "^1.0.0",
-                    "minimalistic-crypto-utils": "^1.0.0"
-                  }
+                  "version": "^6.5.3"
                 }
               }
             }
@@ -7359,7 +7251,7 @@
           "requires": {
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
+            "elliptic": "^6.5.3",
             "ethereum-cryptography": "^0.1.3",
             "ethjs-util": "^0.1.3",
             "rlp": "^2.0.0",
@@ -7367,18 +7259,7 @@
           },
           "dependencies": {
             "elliptic": {
-              "version": "6.5.3",
-              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-              "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-              "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
-              }
+              "version": "^6.5.3"
             }
           }
         }
@@ -7441,25 +7322,14 @@
             "@types/bn.js": "^4.11.3",
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
+            "elliptic": "^6.5.3",
             "ethereum-cryptography": "^0.1.3",
             "ethjs-util": "0.1.6",
             "rlp": "^2.2.3"
           },
           "dependencies": {
             "elliptic": {
-              "version": "6.5.3",
-              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-              "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-              "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
-              }
+              "version": "^6.5.3"
             }
           }
         }
@@ -7487,7 +7357,7 @@
           "requires": {
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
+            "elliptic": "^6.5.3",
             "ethereum-cryptography": "^0.1.3",
             "ethjs-util": "^0.1.3",
             "rlp": "^2.0.0",
@@ -7495,18 +7365,7 @@
           },
           "dependencies": {
             "elliptic": {
-              "version": "6.5.3",
-              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-              "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-              "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
-              }
+              "version": "^6.5.3"
             }
           }
         }
@@ -7536,7 +7395,7 @@
           "requires": {
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
+            "elliptic": "^6.5.3",
             "ethereum-cryptography": "^0.1.3",
             "ethjs-util": "^0.1.3",
             "rlp": "^2.0.0",
@@ -7544,18 +7403,7 @@
           },
           "dependencies": {
             "elliptic": {
-              "version": "6.5.3",
-              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-              "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-              "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
-              }
+              "version": "^6.5.3"
             }
           }
         }
@@ -7592,7 +7440,7 @@
           "requires": {
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
+            "elliptic": "^6.5.3",
             "ethereum-cryptography": "^0.1.3",
             "ethjs-util": "^0.1.3",
             "rlp": "^2.0.0",
@@ -7600,18 +7448,7 @@
           },
           "dependencies": {
             "elliptic": {
-              "version": "6.5.3",
-              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-              "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-              "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
-              }
+              "version": "^6.5.3"
             }
           }
         }
@@ -7672,7 +7509,7 @@
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
+                "elliptic": "^6.5.3",
                 "ethereum-cryptography": "^0.1.3",
                 "ethjs-util": "^0.1.3",
                 "rlp": "^2.0.0",
@@ -7680,18 +7517,7 @@
               },
               "dependencies": {
                 "elliptic": {
-                  "version": "6.5.3",
-                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-                  "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-                  "requires": {
-                    "bn.js": "^4.4.0",
-                    "brorand": "^1.0.1",
-                    "hash.js": "^1.0.0",
-                    "hmac-drbg": "^1.0.0",
-                    "inherits": "^2.0.1",
-                    "minimalistic-assert": "^1.0.0",
-                    "minimalistic-crypto-utils": "^1.0.0"
-                  }
+                  "version": "^6.5.3"
                 }
               }
             }
@@ -7714,25 +7540,14 @@
             "@types/bn.js": "^4.11.3",
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
+            "elliptic": "^6.5.3",
             "ethereum-cryptography": "^0.1.3",
             "ethjs-util": "0.1.6",
             "rlp": "^2.2.3"
           },
           "dependencies": {
             "elliptic": {
-              "version": "6.5.3",
-              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-              "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-              "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
-              }
+              "version": "^6.5.3"
             }
           }
         }
@@ -7745,7 +7560,7 @@
       "requires": {
         "aes-js": "3.0.0",
         "bn.js": "^4.4.0",
-        "elliptic": "6.5.3",
+        "elliptic": "^6.5.3",
         "hash.js": "1.1.3",
         "js-sha3": "0.5.7",
         "scrypt-js": "2.0.4",
@@ -7765,18 +7580,7 @@
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
         },
         "elliptic": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-          "requires": {
-            "bn.js": "^4.4.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0",
-            "minimalistic-crypto-utils": "^1.0.0"
-          }
+          "version": "^6.5.3"
         },
         "hash.js": {
           "version": "1.1.3",
@@ -9227,21 +9031,14 @@
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
       "integrity": "sha512-yHYTgWMQO8VvwNS22eLLloAkvungsKdKTLO8AJlftYIKNfJr3GK3zK0ZCfzDDGUBttdGc8xFy1mCitvNKQtC3Q==",
       "requires": {
-        "http-proxy": "^1.17.0",
+        "http-proxy": "^1.18.1",
         "is-glob": "^4.0.0",
         "lodash": "^4.17.11",
         "micromatch": "^3.1.10"
       },
       "dependencies": {
         "http-proxy": {
-          "version": "1.18.1",
-          "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-          "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-          "requires": {
-            "eventemitter3": "^4.0.0",
-            "follow-redirects": "^1.0.0",
-            "requires-port": "^1.0.0"
-          }
+          "version": "^1.18.1"
         }
       }
     },
@@ -11694,7 +11491,7 @@
           "requires": {
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
+            "elliptic": "^6.5.3",
             "ethereum-cryptography": "^0.1.3",
             "ethjs-util": "^0.1.3",
             "rlp": "^2.0.0",
@@ -11702,18 +11499,7 @@
           },
           "dependencies": {
             "elliptic": {
-              "version": "6.5.3",
-              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-              "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-              "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
-              }
+              "version": "^6.5.3"
             }
           }
         },
@@ -15607,7 +15393,7 @@
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
       "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
       "requires": {
-        "elliptic": "^6.5.2",
+        "elliptic": "^6.5.3",
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0"
       },
@@ -15618,18 +15404,7 @@
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
         },
         "elliptic": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-          "requires": {
-            "bn.js": "^4.4.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0",
-            "minimalistic-crypto-utils": "^1.0.0"
-          }
+          "version": "^6.5.3"
         }
       }
     },
@@ -15647,9 +15422,7 @@
       },
       "dependencies": {
         "node-forge": {
-          "version": "0.10.0",
-          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-          "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+          "version": "^0.10.0"
         }
       }
     },
@@ -18552,25 +18325,14 @@
                 "@types/bn.js": "^4.11.3",
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
+                "elliptic": "^6.5.3",
                 "ethereum-cryptography": "^0.1.3",
                 "ethjs-util": "0.1.6",
                 "rlp": "^2.2.3"
               },
               "dependencies": {
                 "elliptic": {
-                  "version": "6.5.3",
-                  "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-                  "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-                  "requires": {
-                    "bn.js": "^4.4.0",
-                    "brorand": "^1.0.1",
-                    "hash.js": "^1.0.0",
-                    "hmac-drbg": "^1.0.0",
-                    "inherits": "^2.0.1",
-                    "minimalistic-assert": "^1.0.0",
-                    "minimalistic-crypto-utils": "^1.0.0"
-                  }
+                  "version": "^6.5.3"
                 }
               }
             }
@@ -18583,7 +18345,7 @@
           "requires": {
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
+            "elliptic": "^6.5.3",
             "ethereum-cryptography": "^0.1.3",
             "ethjs-util": "^0.1.3",
             "rlp": "^2.0.0",
@@ -18591,18 +18353,7 @@
           },
           "dependencies": {
             "elliptic": {
-              "version": "6.5.3",
-              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-              "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-              "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
-              }
+              "version": "^6.5.3"
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "serve": "^11.3.2",
     "truncate-middle": "^1.0.6",
     "walletlink": "^2.0.2",
-    "web3": "1.0.0-beta.55"
+    "web3": "1.3.4"
   },
   "scripts": {
     "preinstall": "npx npm-force-resolutions",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": "12.16.1"
+    "node": ">=12.16.1"
   },
   "dependencies": {
     "@ledgerhq/hw-app-eth": "^5.27.2",
@@ -11,6 +11,7 @@
     "@material-ui/core": "^4.8.3",
     "@material-ui/icons": "^4.5.1",
     "@material-ui/lab": "^4.0.0-alpha.39",
+    "@metamask/legacy-web3": "^2.0.0",
     "@omisego/omg-js": "^4.1.2-1.0.4",
     "@sentry/react": "^5.21.4",
     "@walletconnect/web3-provider": "^1.0.0-rc.3",

--- a/src/actions/tokenAction.js
+++ b/src/actions/tokenAction.js
@@ -27,10 +27,14 @@ export async function getToken (_currency) {
   }
 
   const tokenContract = new networkService.web3.eth.Contract(erc20abi, currency);
-  const callOptions = { from: currency };
+
+  //this breaks web3.js 1.3.4
+  //const callOptions = { from: currency };
+  //tokenContract.methods.symbol().call(callOptions) will fail
+
   const [ _name, _decimals ] = await Promise.all([
-    tokenContract.methods.symbol().call(callOptions),
-    tokenContract.methods.decimals().call(callOptions)
+    tokenContract.methods.symbol().call(),
+    tokenContract.methods.decimals().call()
   ]).catch(e => [ null, null ]);
 
   const decimals = _decimals ? Number(_decimals.toString()) : 0;

--- a/src/services/networkService.js
+++ b/src/services/networkService.js
@@ -812,6 +812,8 @@ class NetworkService {
   async depositEth (value, gasPrice) {
     try {
       const valueBN = new BN(value.toString());
+      console.log("trying to deposit ETH")
+      console.log("Gasprice:", gasPrice.toString())
       const result = await this.rootChain.deposit({
         amount: valueBN,
         txOptions: {
@@ -819,6 +821,7 @@ class NetworkService {
           gasPrice: gasPrice.toString()
         }
       });
+
       // normalize against deposits from pastevents
       const deposit = {
         ...result,
@@ -832,7 +835,7 @@ class NetworkService {
     } catch (error) {
       throw new WebWalletError({
         originalError: error,
-        customErrorMessage: 'Could not deposit ETH. Please try again.',
+        customErrorMessage: 'Could not deposit ETH. Please check to make sure you have enough ETH to cover both the amount you want to deposit and the associated gas fees.',
         reportToSentry: false,
         reportToUi: true
       });
@@ -862,7 +865,7 @@ class NetworkService {
     } catch (error) {
       throw new WebWalletError({
         originalError: error,
-        customErrorMessage: 'Could not deposit ERC20. Please try again.',
+        customErrorMessage: 'Could not deposit ERC20. Please check to make sure you have sufficient funds to cover both the amount you want to deposit and the associated gas fees.',
         reportToSentry: false,
         reportToUi: true
       });

--- a/src/services/networkService.js
+++ b/src/services/networkService.js
@@ -29,6 +29,7 @@ import { bufferToHex } from 'ethereumjs-util';
 import erc20abi from 'human-standard-token-abi';
 
 import Web3 from 'web3';
+import '@metamask/legacy-web3'
 import WalletConnectProvider from '@walletconnect/web3-provider';
 import WalletLink from 'walletlink';
 

--- a/src/services/networkService.js
+++ b/src/services/networkService.js
@@ -812,8 +812,6 @@ class NetworkService {
   async depositEth (value, gasPrice) {
     try {
       const valueBN = new BN(value.toString());
-      console.log("trying to deposit ETH")
-      console.log("Gasprice:", gasPrice.toString())
       const result = await this.rootChain.deposit({
         amount: valueBN,
         txOptions: {


### PR DESCRIPTION
Metamask dropped Web3.js injection, but provided a `legacy support` package. This is not a longer term fix, but allows things to work for now. Ran `yarn add @metamask/legacy-web3` and added the import into networkService.js. Also relaxed the `node.js` requirement so that more current versions of node work.  